### PR TITLE
fix(ContentTileChevron): add title validation to prevent rendering

### DIFF
--- a/lib/components/organisms/ContentTile/content-tile-chevron.tsx
+++ b/lib/components/organisms/ContentTile/content-tile-chevron.tsx
@@ -12,9 +12,9 @@ export const ContentTileChevron = (): JSX.Element | null => {
 
   if (!isContextValid(tileContext)) return null;
 
-  const { ctaLink } = tileContext.configuration as ContentTileConfig;
+  const { ctaLink, title } = tileContext.configuration as ContentTileConfig;
 
-  if (!ctaLink) return null;
+  if (!ctaLink || !title) return null;
 
   return (
     <Icon


### PR DESCRIPTION
Ensure the chevron doesn't render if the title is missing, in addition to the existing ctaLink check