### PR TITLE
feat(storybook): add font family selection to storybook preview

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,10 @@
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400;500;700;900&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300..800&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Lato:wght@100;300;400;700;900&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@100..900&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@200..900&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@200..1000&display=swap" rel="stylesheet" />

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -145,8 +145,38 @@ export const MockSectionProvider: React.FC<MockSectionProviderProps> = ({
 const preview: Preview = {
   decorators: [
     (Story, context) => {
-      const selectedTheme = context.globals.theme as ThemeName;
-      const theme = themes[selectedTheme] || defaultTheme;
+      const selectedTheme = context.globals.theme || 'default';
+      const selectedFont = context.globals.fontFamily || 'system';
+      const baseTheme = themes[selectedTheme as ThemeName] || defaultTheme;
+
+      const getFontFamily = (font: string) => {
+        switch (font) {
+          case 'Inter':
+            return '"Inter", sans-serif';
+          case 'Roboto':
+            return '"Roboto", sans-serif';
+          case 'Open Sans':
+            return '"Open Sans", sans-serif';
+          case 'Lato':
+            return '"Lato", sans-serif';
+          case 'Montserrat':
+            return '"Montserrat", sans-serif';
+          case 'Poppins':
+            return '"Poppins", sans-serif';
+          case 'Source Sans 3':
+            return '"Source Sans 3", sans-serif';
+          case 'Nunito':
+            return '"Nunito", sans-serif';
+          default:
+            return baseTheme.fontFamily;
+        }
+      };
+
+      // Create a new theme object with the selected font family
+      const theme = {
+        ...baseTheme,
+        fontFamily: getFontFamily(selectedFont),
+      };
 
       return (
         <WllSdkProvider theme={theme} config={sdkConfig}>
@@ -190,6 +220,25 @@ const preview: Preview = {
           { value: 'warm', title: 'Warm' },
           { value: 'forest', title: 'Forest' },
           { value: 'sunset', title: 'Sunset' },
+        ],
+      },
+    },
+    fontFamily: {
+      name: 'Font Family',
+      description: 'Global font family for all stories',
+      defaultValue: 'system',
+      toolbar: {
+        icon: 'book',
+        items: [
+          { value: 'system', title: 'System Default' },
+          { value: 'Inter', title: 'Inter' },
+          { value: 'Roboto', title: 'Roboto' },
+          { value: 'Open Sans', title: 'Open Sans' },
+          { value: 'Lato', title: 'Lato' },
+          { value: 'Montserrat', title: 'Montserrat' },
+          { value: 'Poppins', title: 'Poppins' },
+          { value: 'Source Sans 3', title: 'Source Sans 3' },
+          { value: 'Nunito', title: 'Nunito' },
         ],
       },
     },


### PR DESCRIPTION
Add support for multiple font families in Storybook preview by:
- Adding font preconnect links in preview-head.html
- Implementing font family selection in preview.tsx
- Creating a new toolbar control for font selection