### PR TITLE
fix: add ability to refresh internally with hook

### DIFF
--- a/lib/components/organisms/Group/index.tsx
+++ b/lib/components/organisms/Group/index.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState } from 'react';
-import { ScrollView, View } from 'react-native';
+import { View } from 'react-native';
 import { IS_MOBILE, IS_WEB } from '../../../constants/device';
 import { useWllSdk } from '../../../context/WllSdkContext';
 import { useGroupRefresh } from '../../../hooks/useGroupRefresh';
@@ -117,10 +117,8 @@ export const GroupSections = (): JSX.Element => {
 
   const sortedSections = sortByPriority(activeSections);
 
-  const Container = IS_WEB ? View : ScrollView;
-
   return (
-    <Container
+    <View
       accessible
       accessibilityLabel={`Group: ${groupData.name || 'Unnamed group'}`}
       role="region"
@@ -128,7 +126,7 @@ export const GroupSections = (): JSX.Element => {
       {sortedSections.map((section) => (
         <Section key={section.id} section={section} />
       ))}
-    </Container>
+    </View>
   );
 };
 


### PR DESCRIPTION
Because of internal scrollview it doesn't allow adding pull down to refresh control from external app. This adds and exposes the hooks to refresh the sdk from external apps. 