### PR TITLE
feat(chip): add new Chip component with status variants

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -8,7 +8,9 @@ console.warn = (...args) => {
   const warningsToSuppress = [
     'accessibilityLabel',
     'aria-label',
-    'style.resizeMode is deprecated'
+    'style.resizeMode is deprecated',
+    'accessibilityLiveRegion is deprecated',
+    'accessibilityRole is deprecated'
   ];
 
   // Check if the warning message includes any of the suppressed warnings

--- a/lib/components/atoms/Chip/Chip.spec.tsx
+++ b/lib/components/atoms/Chip/Chip.spec.tsx
@@ -1,0 +1,45 @@
+import Color from 'color';
+import React from 'react';
+import { render } from '../../__test__/test-utils';
+import { defaultTheme } from '../../../utils/styling';
+import Chip from './index';
+import { StatusVariant } from '../../../types/tile';
+
+describe('<Chip />', () => {
+  it('renders a string label with default styling and accessibility attributes', () => {
+    const { getByTestId } = render(<Chip label="Active" testID="chip" />);
+
+    const chip = getByTestId('chip');
+    const expectedBackground = Color(defaultTheme.primary).alpha(0.1).string();
+    const computedBackground = window
+      .getComputedStyle(chip)
+      .backgroundColor.replace(/\s/g, '');
+
+    expect(chip).toHaveAttribute('role', 'status');
+    expect(chip).toHaveAttribute('aria-live', 'polite');
+    expect(chip).toHaveAccessibleName('Active');
+    expect(computedBackground).toBe(expectedBackground.replace(/\s/g, ''));
+  });
+
+  it('applies the green variant styles', () => {
+    const { getByTestId } = render(
+      <Chip label="Completed" variant={StatusVariant.GREEN} testID="chip" />
+    );
+
+    const chip = getByTestId('chip');
+    const background = window.getComputedStyle(chip).backgroundColor;
+
+    expect(Color(background).hex().toLowerCase()).toBe('#d1f0e1');
+    expect(chip).toHaveAccessibleName('Completed');
+  });
+
+  it('maps ariaLive="off" to aria-live="off"', () => {
+    const { getByTestId } = render(
+      <Chip label="Pending" ariaLive="off" testID="chip" />
+    );
+
+    const chip = getByTestId('chip');
+
+    expect(chip).toHaveAttribute('aria-live', 'off');
+  });
+});

--- a/lib/components/atoms/Chip/Chip.stories.tsx
+++ b/lib/components/atoms/Chip/Chip.stories.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import Chip, { ChipProps } from './index';
+import { StatusVariant } from '../../../types/tile';
+
+const meta: Meta<typeof Chip> = {
+  title: 'components/atoms/Chip',
+  component: Chip,
+  args: {
+    label: 'Program status',
+    variant: StatusVariant.PRIMARY,
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: Object.values(StatusVariant),
+    },
+  },
+};
+
+export default meta;
+
+const Template: StoryFn<ChipProps> = (args) => <Chip {...args} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  label: 'Program status',
+  variant: StatusVariant.PRIMARY,
+};
+
+export const Green = Template.bind({});
+Green.args = {
+  label: 'Success status',
+  variant: StatusVariant.GREEN,
+};
+
+export const Grey = Template.bind({});
+Grey.args = {
+  label: 'Inactive status',
+  variant: StatusVariant.GREY,
+};

--- a/lib/components/atoms/Chip/index.tsx
+++ b/lib/components/atoms/Chip/index.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import {
+  AccessibilityRole,
+  StyleProp,
+  Text as RNText,
+  TextStyle,
+  View,
+  ViewStyle,
+} from 'react-native';
+import { useWllSdk } from '../../../context/WllSdkContext';
+import { StatusVariant } from '../../../types/tile';
+import { useChipStyles } from './styles';
+
+type ChipLabel = React.ReactNode;
+type AriaLive = 'polite' | 'assertive' | 'off';
+
+type LiveRegionMapping = {
+  native: 'none' | 'polite' | 'assertive';
+  web: 'off' | 'polite' | 'assertive';
+};
+
+export type ChipProps = {
+  label: ChipLabel;
+  variant?: StatusVariant;
+  role?: AccessibilityRole | 'status';
+  ariaLive?: AriaLive;
+  accessibilityLabel?: string;
+  testID?: string;
+  style?: StyleProp<ViewStyle>;
+  labelStyle?: StyleProp<TextStyle>;
+};
+
+const mapLiveRegion = (ariaLive: AriaLive = 'polite'): LiveRegionMapping => {
+  switch (ariaLive) {
+    case 'assertive':
+      return { native: 'assertive', web: 'assertive' };
+    case 'off':
+      return { native: 'none', web: 'off' };
+    case 'polite':
+    default:
+      return { native: 'polite', web: 'polite' };
+  }
+};
+
+const Chip = ({
+  label,
+  variant = StatusVariant.PRIMARY,
+  role = 'status',
+  ariaLive = 'polite',
+  accessibilityLabel,
+  testID,
+  style,
+  labelStyle,
+}: ChipProps): React.ReactElement => {
+  const styles = useChipStyles();
+  const { theme } = useWllSdk();
+
+  const variantStyles = React.useMemo(() => {
+    switch (variant) {
+      case StatusVariant.GREEN:
+        return {
+          container: { backgroundColor: '#d1f0e1' },
+          label: { color: '#128e55' },
+        };
+      case StatusVariant.GREY:
+        return {
+          container: { backgroundColor: '#dadde0' },
+          label: { color: '#666666' },
+        };
+      case StatusVariant.PRIMARY:
+      default:
+        return {
+          container: {
+            backgroundColor: theme.alphaDerivedPrimary?.[10] ?? theme.primary,
+          },
+          label: { color: theme.primary },
+        };
+    }
+  }, [theme, variant]);
+
+  const computedAccessibilityLabel =
+    accessibilityLabel ?? (typeof label === 'string' ? label : undefined);
+  const { native: accessibilityLiveRegion, web: ariaLiveValue } =
+    mapLiveRegion(ariaLive);
+  const isSimpleLabel = typeof label === 'string';
+  const isIndividuallyAccessible = computedAccessibilityLabel !== undefined;
+
+  return (
+    <View
+      style={[styles.container, variantStyles.container, style]}
+      accessible={isIndividuallyAccessible}
+      accessibilityRole={role as AccessibilityRole}
+      accessibilityLiveRegion={accessibilityLiveRegion}
+      accessibilityLabel={computedAccessibilityLabel}
+      aria-live={ariaLiveValue}
+      testID={testID}
+    >
+      {isSimpleLabel ? (
+        <RNText
+          style={[styles.label, variantStyles.label, labelStyle]}
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          accessible={false}
+          importantForAccessibility="no"
+        >
+          {label}
+        </RNText>
+      ) : (
+        label
+      )}
+    </View>
+  );
+};
+
+export default Chip;

--- a/lib/components/atoms/Chip/styles.ts
+++ b/lib/components/atoms/Chip/styles.ts
@@ -1,0 +1,40 @@
+import { StyleSheet } from 'react-native';
+import { useWllSdk } from '../../../context/WllSdkContext';
+import { useResponsive } from '../../../hooks/useResponsive';
+import { useResponsiveValue } from '../../../utils/responsiveHelper';
+
+export const useChipStyles = () => {
+  const { theme } = useWllSdk();
+  const { isDesktop, isTablet } = useResponsive();
+
+  const paddingHorizontal = useResponsiveValue(12, 8, isDesktop, isTablet);
+  const paddingVertical = useResponsiveValue(6, 3, isDesktop, isTablet);
+  const fontSize = useResponsiveValue(
+    theme.sizes.sm,
+    theme.sizes.xs,
+    isDesktop,
+    isTablet
+  );
+  const lineHeight = Math.max(fontSize, Math.round(fontSize * 1.3));
+
+  return StyleSheet.create({
+    container: {
+      alignSelf: 'flex-start',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexDirection: 'row',
+      paddingHorizontal,
+      paddingVertical,
+      borderRadius: theme.sizes.borderRadiusRounded,
+      overflow: 'hidden',
+      flexShrink: 1,
+    },
+    label: {
+      fontFamily: theme.fontFamily,
+      fontSize,
+      lineHeight,
+      fontWeight: '400',
+      flexShrink: 1,
+    },
+  });
+};

--- a/lib/components/atoms/index.ts
+++ b/lib/components/atoms/index.ts
@@ -5,11 +5,10 @@ export { default as LoadingIndicator } from './LoadingIndicator';
 export { default as ProgressBar } from './ProgressBar';
 export { default as ProgressiveImage } from './ProgressiveImage';
 export { default as Text } from './Text';
-
 export { default as BaseBanner } from './BaseBanner';
 export { default as BaseTile } from './BaseTile';
 export { default as Indicator } from './Indicator';
 export { default as Skeleton } from './Skeleton';
 export { default as TileContainer } from './TileContainer';
-
 export { Column, FullFlex, Layout, Row, Spacer } from './Primatives';
+export { default as Chip } from './Chip';

--- a/lib/components/molecules/Grid/__snapshots__/Grid.spec.tsx.snap
+++ b/lib/components/molecules/Grid/__snapshots__/Grid.spec.tsx.snap
@@ -80,14 +80,16 @@ exports[`<Grid /> matches snapshot 1`] = `
                 />
                 <div
                   aria-label="Badge earned on 27/01/2025"
-                  class="css-view-175oi2r r-alignItems-1habvwh r-borderRadius-y47klf r-paddingBlock-cnw61z r-paddingInline-is05cd"
+                  aria-live="polite"
+                  class="css-view-175oi2r r-alignItems-1awozwy r-alignSelf-k200y r-borderRadius-sdzlij r-flexDirection-18u37iz r-flexShrink-1wbh5a2 r-justifyContent-1777fci r-overflow-1udh08x r-paddingBlock-vuvdlw r-paddingInline-3o4zer"
                   data-testid="badge-tile-date-earned"
-                  style="background-color: rgba(57, 46, 215, 0.2);"
+                  role="status"
+                  style="background-color: rgba(57, 46, 215, 0.1);"
                 >
                   <div
-                    class="css-text-146c3p1 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-fontFamily-lhg2x6"
+                    class="css-text-146c3p1 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-flexShrink-1wbh5a2 r-fontFamily-lhg2x6 r-fontSize-1enofrn r-fontWeight-16dba41 r-lineHeight-1cwl3u0"
                     dir="auto"
-                    style="font-size: 12px; color: rgb(255, 255, 255);"
+                    style="color: rgb(57, 46, 215);"
                   >
                     Earned on 27/01/2025
                   </div>

--- a/lib/components/organisms/BadgeTile/BadgeTile.spec.tsx
+++ b/lib/components/organisms/BadgeTile/BadgeTile.spec.tsx
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import Color from 'color';
 import { screen } from '@testing-library/react';
 import React from 'react';
 import { BadgeTileType, TileHeight } from '../../../types/tile';
@@ -204,6 +205,21 @@ describe('<BadgeTile />', () => {
       const dateElement = screen.getByTestId('badge-tile-date-earned');
       expect(dateElement).toBeInTheDocument();
       expect(dateElement.textContent).toBe('Badge not earned yet');
+    });
+
+    it('uses grey chip styling when badge is not earned', () => {
+      const notEarnedBadge = createBadgeTileMock({
+        count: 0,
+        type: BadgeTileType.Specific,
+        badgeNotEarnedMessage: 'Badge not earned yet',
+      });
+
+      render(<BadgeTile tile={notEarnedBadge} />);
+
+      const dateElement = screen.getByTestId('badge-tile-date-earned');
+      const background = window.getComputedStyle(dateElement).backgroundColor;
+
+      expect(Color(background).hex().toLowerCase()).toBe('#dadde0');
     });
 
     it('does not render date for Latest type with count=0', () => {

--- a/lib/components/organisms/BadgeTile/badge-tile-date-earned.tsx
+++ b/lib/components/organisms/BadgeTile/badge-tile-date-earned.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
-import { View } from 'react-native';
-import { useWllSdk } from '../../../context/WllSdkContext';
-import { BadgeTileConfig, BadgeTileType } from '../../../types/tile';
-import { isContextValid } from '../../../utils/contextHelpers';
 import {
-  getReadableTextColor,
-  getStateColor,
-} from '../../../utils/themeHelpers';
+  BadgeTileConfig,
+  BadgeTileType,
+  StatusVariant,
+} from '../../../types/tile';
+import { isContextValid } from '../../../utils/contextHelpers';
 import { handleLastEarnedDate } from '../../../utils/transforms';
-import { Text } from '../../atoms';
+import { Chip } from '../../atoms';
 import { useTileContext } from '../../atoms/BaseTile';
-import { useBadgeTileStyles } from './styles';
 
 /**
  * Renders the date earned for a Badge Tile.
@@ -18,9 +15,7 @@ import { useBadgeTileStyles } from './styles';
  * @returns React.ReactElement or null if badge is not earned or badgeNotEarnedMessage exists
  */
 export const BadgeTileDateEarned = (): React.ReactElement | null => {
-  const styles = useBadgeTileStyles();
   const tileContext = useTileContext();
-  const { theme } = useWllSdk();
 
   if (!isContextValid(tileContext)) return null;
 
@@ -47,42 +42,24 @@ export const BadgeTileDateEarned = (): React.ReactElement | null => {
     return null;
   }
 
-  const backgroundColor = getStateColor(
-    theme.alphaDerivedPrimary[20],
-    type,
-    count
-  );
-
-  const containerStyle = [styles.dateEarnedContainer, { backgroundColor }];
-  const textColor = getReadableTextColor(backgroundColor);
+  const formattedDate = handleLastEarnedDate(lastEarnedAt, locale);
 
   const displayText =
     count === 0
       ? badgeNotEarnedMessage
-      : `${awardedDatePrefix} ${handleLastEarnedDate(lastEarnedAt, locale)}`;
+      : `${awardedDatePrefix} ${formattedDate}`;
 
   const accessibilityLabel =
     count === 0
       ? 'Badge not yet earned'
-      : `Badge earned on ${handleLastEarnedDate(lastEarnedAt, locale)}`;
+      : `Badge earned on ${formattedDate}`;
 
   return (
-    <View
-      style={containerStyle}
-      accessible
+    <Chip
+      label={displayText}
+      variant={count === 0 ? StatusVariant.GREY : StatusVariant.PRIMARY}
       accessibilityLabel={accessibilityLabel}
       testID="badge-tile-date-earned"
-    >
-      <Text
-        variant="label"
-        style={[styles.dateEarnedText, { color: textColor }]}
-        numberOfLines={1}
-        ellipsizeMode="tail"
-        accessibilityElementsHidden={true}
-        importantForAccessibility="no-hide-descendants"
-      >
-        {displayText}
-      </Text>
-    </View>
+    />
   );
 };

--- a/lib/types/tile.ts
+++ b/lib/types/tile.ts
@@ -33,6 +33,12 @@ export enum TileHeight {
 
 export type ProgessType = 'NAME' | 'POINTS';
 
+export enum StatusVariant {
+  PRIMARY = 'primary',
+  GREEN = 'green',
+  GREY = 'grey',
+}
+
 export class BannerTileConfig {
   artworkUrl?: string | null;
   title?: string | null;


### PR DESCRIPTION
- Implement Chip component with primary, green and grey status variants
- Add responsive styling and accessibility support
- Replace custom badge date styling with new Chip component
- Include Storybook stories and unit tests