### PR TITLE
feat: make sizes configurable in the theme

### DIFF
--- a/lib/context/WllSdkContext.tsx
+++ b/lib/context/WllSdkContext.tsx
@@ -70,8 +70,8 @@ type WllSdkContextType = ThemeContextType & {
     callback: (data?: any) => void
   ) => () => void;
 } & Readonly<{
-    readonly config: SDKConfig;
-  }>;
+  readonly config: SDKConfig;
+}>;
 
 type WllSdkProviderProps = WithChildren & {
   theme?: Partial<BaseThemeObject>;
@@ -80,14 +80,18 @@ type WllSdkProviderProps = WithChildren & {
 };
 
 const createTheme = (baseTheme: Partial<BaseThemeObject> = {}): ThemeObject => {
+  const { sizes: userSizes, ...restBaseTheme } = baseTheme;
   const mergedTheme = {
     ...defaultTheme,
-    ...baseTheme,
+    ...restBaseTheme,
   } as BaseThemeObject;
 
   return {
     ...mergedTheme,
-    sizes,
+    sizes: {
+      ...sizes,
+      ...userSizes,
+    },
     derivedBackground: getDerivedColor(mergedTheme.background),
     primaryText: getReadableTextColor(mergedTheme.primary),
     accentText: getReadableTextColor(mergedTheme.accent),

--- a/lib/types/theme.ts
+++ b/lib/types/theme.ts
@@ -1,4 +1,3 @@
-import { sizes } from '../utils/styling';
 import { WithChildren } from './helpers';
 import { BadgeTileType } from './tile';
 
@@ -9,6 +8,24 @@ export type DerivedColors = {
 
 // TODO: Add more types when needed
 export type DesaturationType = BadgeTileType.Specific | BadgeTileType.Latest;
+
+export type Sizes = {
+  borderRadiusSm: number;
+  borderRadiusLg: number;
+  borderRadiusButton: number;
+  borderRadiusRounded: number;
+  xxxs: number;
+  xxs: number;
+  xs: number;
+  sm: number;
+  md: number;
+  lg: number;
+  xl: number;
+  xxl: number;
+  xxxl: number;
+  xxxxl: number;
+  xxxxxl: number;
+};
 
 export type BaseThemeObject = {
   fontFamily: string;
@@ -23,6 +40,7 @@ export type BaseThemeObject = {
   surface: string;
   surfaceText: string;
   text: string;
+  sizes?: Partial<Sizes>;
 };
 
 export type DerivedProperties = {
@@ -39,7 +57,7 @@ export type DerivedProperties = {
 
 export type ThemeObject = BaseThemeObject &
   DerivedProperties & {
-    readonly sizes: typeof sizes;
+    sizes: Sizes;
   };
 
 export type ThemeContextType = {


### PR DESCRIPTION
Currently the sizes are hardcoded and non-configurable. This is a minor change to allow sizes to be overwritten inside of the theme by expecting only a partial sizes object. If not all sizes are provided, the remaining ones fallback to the default value.