### PR TITLE
fix(ContentTile): use fixed aspect ratio for content tiles on mobile

### DIFF
--- a/lib/components/organisms/ContentTile/ContentTile.spec.tsx
+++ b/lib/components/organisms/ContentTile/ContentTile.spec.tsx
@@ -3,6 +3,7 @@ import { createContentTileMock } from '../../../mocks/tiles';
 import { TileHeight } from '../../../types/tile';
 import { render } from '../../__test__/test-utils';
 import { ContentTile } from './index';
+import { getContentTileMediaContainerStyle } from './content-tile-media';
 
 const ContentTileMock = createContentTileMock();
 
@@ -44,6 +45,13 @@ describe('<ContentTile /> Rendering States', () => {
       <ContentTile tile={halfSizeTileWithArtwork} />
     );
     expect(queryByTestId('tile-content')).toBeNull();
+  });
+
+  it('uses a square aspect ratio for artwork-only media', () => {
+    expect(getContentTileMediaContainerStyle(true)).toMatchObject({
+      flexBasis: '100%',
+      aspectRatio: 1,
+    });
   });
 
   it('handles inactive tile gracefully', () => {

--- a/lib/components/organisms/ContentTile/content-tile-media.tsx
+++ b/lib/components/organisms/ContentTile/content-tile-media.tsx
@@ -5,7 +5,6 @@ import { isContextValid } from '../../../utils/contextHelpers';
 import { ProgressiveImage } from '../../atoms';
 import { useTileContext } from '../../atoms/BaseTile';
 import { useContentTileStyles } from './styles';
-import { IS_WEB } from '../../../constants/device';
 
 // We are using percentage values for flexBasis, which is valid in
 // React Native but TypeScript expects a number.
@@ -16,6 +15,16 @@ type ResponsiveViewStyle = StyleProp<ViewStyle> & {
 type ContentTileMediaProps = {
   isArtworkOnly: boolean;
 };
+
+export const getContentTileMediaContainerStyle = (
+  isArtworkOnly: boolean
+): ResponsiveViewStyle =>
+  isArtworkOnly
+    ? {
+        flexBasis: '100%',
+        aspectRatio: 1,
+      }
+    : { flexBasis: '50%' };
 
 export const ContentTileMedia = ({
   isArtworkOnly,
@@ -32,10 +41,7 @@ export const ContentTileMedia = ({
   const hasArtwork = Boolean(artworkUrl);
   const styles = useContentTileStyles(hasArtwork);
 
-  const containerStyle: ResponsiveViewStyle = {
-    flexBasis: isArtworkOnly ? '100%' : '50%',
-    ...(isArtworkOnly && IS_WEB && { aspectRatio: 1 }),
-  };
+  const containerStyle = getContentTileMediaContainerStyle(isArtworkOnly);
 
   return (
     <View


### PR DESCRIPTION
Root cause looks like ContentTileMedia was only applying aspectRatio: 1 behind IS_WEB, so native/mobile image-only content tiles could fall back to non-square layout. I removed that web-only gate in [content-tile-media.tsx](/lib/components/organisms/ContentTile/content-tile-media.tsx)