### PR TITLE
Restore React 18 / RN 0.77 consumer support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,31 +2,69 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20.19.4
-        cache: 'yarn'
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.19.4
+          cache: 'yarn'
 
-    - name: Install dependencies
-      run: yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
-    - name: Run tests
-      run: yarn test
+      - name: Run tests
+        run: yarn test
 
-    - name: Type check
-      run: yarn type-check
+      - name: Type check
+        run: yarn type-check
 
-    - name: Build
-      run: yarn build
+      - name: Build
+        run: yarn build
+
+  test-react18:
+    name: Test (React 18)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.19.4
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      # Override the React/RN dev deps to the 18 line to verify the SDK still
+      # builds, type-checks and tests cleanly against React 18 consumers.
+      # Lockfile changes here are intentional and discarded with the runner.
+      - name: Pin React 18 + compatible React Native
+        run: |
+          yarn add --dev --ignore-scripts \
+            react@18.3.1 \
+            react-dom@18.3.1 \
+            react-test-renderer@18.3.1 \
+            @types/react@^18.3.0 \
+            @types/react-dom@^18.3.0 \
+            react-native@0.77.2
+
+      - name: Run tests
+        run: yarn test
+
+      - name: Type check
+        run: yarn type-check
+
+      - name: Build
+        run: yarn build

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
+    "react": ">=18.2.0 <20.0.0",
+    "react-dom": ">=18.2.0 <20.0.0",
     "react-native": ">=0.77.0",
     "react-native-web": "^0.19.0"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ import typescript from '@rollup/plugin-typescript';
 import { dts } from 'rollup-plugin-dts';
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
-const external = [
+const externalPackages = [
   'react',
   'react-dom',
   'react-native',
@@ -14,6 +14,17 @@ const external = [
   'lucide-react',
   'zod',
 ];
+// Match bare specifiers AND any subpath (e.g. `react/jsx-runtime`,
+// `react/jsx-dev-runtime`, `react-dom/client`). Plain string entries in
+// rollup's `external` only match the exact specifier, which would let the
+// automatic JSX runtime get inlined and pin consumers to the version of
+// React the SDK was built against.
+const externalPattern = new RegExp(
+  `^(${externalPackages
+    .map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|')})(/|$)`
+);
+const external = (id) => externalPattern.test(id);
 
 const baseConfig = {
   input: 'lib/index.ts',


### PR DESCRIPTION
### Summary
Restores the ability for consumer apps on React 18 / React Native 0.77 to install and use the SDK without runtime crashes. The recent move to React 19 / RN 0.81 broke the React 18 line on two axes: the peer-dependency range excluded it, and the native bundle silently inlined React 19 dev internals.

What was broken
A consumer app on React Native 0.77.3 (which pins React 18.3.1) saw the SDK crash on first render of WllSdkProvider:
```
TypeError: Cannot read properties of undefined (reading 'recentlyCreatedOwnerStacks')
    at reactJsxRuntime_development.jsx (.../dist/native.js)
    at <SDK component>
```
recentlyCreatedOwnerStacks is a React 19-only field on ReactSharedInternals (part of the new owner-stack/captureOwnerStack machinery). It doesn't exist on React 18, so accessing it returns undefined, and the ++ throws.

### Root cause
Two issues compounded:

peerDependencies.react was pinned to ^19.1.0. This excluded the entire React 18 line.
The native rollup bundle inlined React 19's jsx-dev-runtime. The build's external field in rollup.config.js was a plain-string array (['react', 'react-dom', ...]), which rollup matches by exact specifier. The native pipeline routes JSX through @rollup/plugin-typescript with jsx: 'react-jsx', so TypeScript emits import { jsx } from 'react/jsx-runtime'. Because 'react/jsx-runtime' did not match the bare 'react' external, rollup resolved that subpath from node_modules (React 19) and inlined the entire jsx-runtime shim — including its development-mode branch — into dist/native.js. When a consumer on React 18 ran the SDK, the inlined React 19 dev code accessed ReactSharedInternals.recentlyCreatedOwnerStacks on an 18-shaped ReactSharedInternals and crashed.
The web bundle was already safe because tsconfig.json's "jsx": "react" (classic transform) applies to that pipeline and emits React.createElement calls with no jsx-runtime import to inline.

What this PR changes
package.json — peer deps widened so consumers on both lines install cleanly:
react: ^19.1.0 → >=18.2.0 <20.0.0
react-dom: ^19.1.0 → >=18.2.0 <20.0.0
react-native: >=0.77.0 (unchanged — already covers both)
rollup.config.js — external switched from a plain-string array to a function backed by a regex that matches both the bare specifier and any subpath:
```
^(react|react-dom|react-native|react-native-web|color|lucide-react|zod)(/|$)
```
Now react/jsx-runtime, react/jsx-dev-runtime, react-dom/client, react-native/Libraries/... etc. are left as require(...) calls in the bundle and resolve to whichever versions the consumer has installed.
.github/workflows/ci.yml — added a test-react18 job that installs the React 18 line on top of the standard install and runs yarn test, yarn type-check, and yarn build. Sits alongside the existing React 19 job so the dual support doesn't silently regress.
Verification
dist/native.js now starts with require('react/jsx-runtime') as an external call rather than inlining the React 19 dev shim.
recentlyCreatedOwnerStacks occurrences in dist/native.js drop from 2 → 0; dist/web.js remains at 0.
Runtime smoke test: packed the SDK with yarn pack, installed into a throwaway project pinned to react@18.3.1 + react-dom@18.3.1 + react-native@0.77.2, and rendered an SDK component through react-test-renderer. The pre-fix bundle reproduced the user's exact crash; the rebuilt bundle renders cleanly.
Type smoke test: tsc --noEmit clean against both react@18.3.1 + @types/react@^18.3 and react@19.1.0 + @types/react@^19.1 consumers using the same SDK surface (provider, hook, organism JSX, named type exports).
Local yarn test, yarn type-check, yarn build all pass on the React 19 baseline.